### PR TITLE
Alternative HTTP remote port and path

### DIFF
--- a/scripts/templates/proxy.conf
+++ b/scripts/templates/proxy.conf
@@ -21,7 +21,7 @@ server {
     
     # For service: {{service_name}}
     location {{services[service_name]['location']}} {
-        proxy_pass http://{{service_name|lower}}/;
+        proxy_pass http://{{service_name|lower}}:{{services[service_name]['port']}}{{services[service_name]['remote_path']}};
     }{% endfor %}
 }
 {%- endif %}

--- a/scripts/templates/proxy.conf
+++ b/scripts/templates/proxy.conf
@@ -4,7 +4,7 @@ upstream {{service_name|lower}} {
     {{service['balancing_type']}};
     {%- endif %}
     {%- for address in service['addresses'] %}
-    server {{address}};
+    server {{address}}:{{services[service_name]['port']}};
     {%- endfor %}
 }
 {% endfor %}
@@ -21,7 +21,7 @@ server {
     
     # For service: {{service_name}}
     location {{services[service_name]['location']}} {
-        proxy_pass http://{{service_name|lower}}:{{services[service_name]['port']}}{{services[service_name]['remote_path']}};
+        proxy_pass http://{{service_name|lower}}{{services[service_name]['remote_path']}};
     }{% endfor %}
 }
 {%- endif %}


### PR DESCRIPTION
Added ability to customize remote path and port.
I actually found the issue while load-balancing Tomcat Webapp. I had an app server at port 8080 and app at path /javaapp.
