### PR TITLE
Use HTTP/1.1 with proxy_pass

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,5 +19,4 @@ VOLUME ["/etc/nginx/ssl/", "/scripts/"]
 EXPOSE 80 443
 
 WORKDIR /scripts/
-ENTRYPOINT ["python", "startup.py"]
-CMD []
+CMD ["python", "startup.py"]

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ Generates (/etc/nginx/sites-enabled/proxy.conf):
             proxy_pass http://webapp:80/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_buffering off;
         }
     }
 
@@ -100,11 +103,17 @@ Generates (/etc/nginx/sites-enabled/proxy.conf):
             proxy_pass http://webapp:80/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_buffering off;
         }
         location /api/ {
             proxy_pass http://api:80/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_buffering off;
         }
     }
 
@@ -118,5 +127,8 @@ Generates (/etc/nginx/sites-enabled/proxy.conf):
             proxy_pass http://tomcat:8080/javaapp;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
+            proxy_http_version 1.1;
+            proxy_set_header Connection "";
+            proxy_buffering off;
         }
     }

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,7 +4,7 @@ worker_processes 4;
 pid /run/nginx.pid;
 
 events {
-    worker_connections 768;
+    worker_connections 2000;
     # multi_accept on;
 }
 
@@ -19,6 +19,7 @@ http {
     tcp_nodelay on;
     keepalive_timeout 65;
     types_hash_max_size 2048;
+    client_max_body_size 10M;
 
     include /etc/nginx/mime.types;
     default_type application/octet-stream;

--- a/scripts/startup.py
+++ b/scripts/startup.py
@@ -210,11 +210,11 @@ def parse_env(env=os.environ):
 
             assert ssl_certificate, 'SSL certificate .pem not provided for https host: %s, please set %s_SSL_CERTIFICATE' % (hostname, formatted_hostname)
             assert ssl_certificate_key, 'SSL certificate .key not provided for https host: %s, please set %s_SSL_CERTIFICATE_KEY' % (hostname, formatted_hostname)
-            assert os.path.isfile(os.path.join('/etc/nginx/ssl/', ssl_certificate)), 'SSL certificate file: %s could not be found for %s' (ssl_certificate, hostname)
-            assert os.path.isfile(os.path.join('/etc/nginx/ssl/', ssl_certificate_key)), 'SSL certificate file: %s could not be found for %s' (ssl_certificate_key, hostname)
+            assert os.path.isfile(os.path.join('/etc/nginx/', ssl_certificate)), 'SSL certificate file: %s could not be found for %s' % (ssl_certificate, hostname)
+            assert os.path.isfile(os.path.join('/etc/nginx/', ssl_certificate_key)), 'SSL certificate file: %s could not be found for %s' % (ssl_certificate_key, hostname)
 
             value['ssl_certificate'] = ssl_certificate
-            value['ssl_key'] = ssl_certificate_key
+            value['ssl_certificate_key'] = ssl_certificate_key
 
     return hosts, services
 

--- a/scripts/startup.py
+++ b/scripts/startup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 '''
-This script will be run on start-up to evaluate the Docker link environment 
-variables and automatically generate upstream and location modules for 
+This script will be run on start-up to evaluate the Docker link environment
+variables and automatically generate upstream and location modules for
 reverse-proxying and load-balancing.
 
 It looks for environment variables in the following formats:
@@ -41,9 +41,9 @@ Generates (/etc/nginx/sites-enabled/proxy.conf):
 
     upstream webapp {
         ip_hash;
-        server 192.168.0.2;    
-        server 192.168.0.3;    
-        server 192.168.0.4;    
+        server 192.168.0.2;
+        server 192.168.0.3;
+        server 192.168.0.4;
     }
 
     upstream api {
@@ -68,16 +68,16 @@ Generates (/etc/nginx/sites-enabled/proxy.conf):
     server {
         listen 443;
         server_name www.example.com;
-    
+
         root html;
         index index.html index.htm;
-    
+
         ssl on;
         ssl_certificate ssl/something.pem;
         ssl_certificate_key ssl/something.key;
-     
+
         ssl_session_timeout 5m;
-    
+
         ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
         ssl_ciphers "HIGH:!aNULL:!MD5 or HIGH:!aNULL:!MD5:!3DES";
         ssl_prefer_server_ciphers on;
@@ -113,15 +113,15 @@ env = Environment(
         )
     )
 parser = argparse.ArgumentParser(
-    description='Docker-based Nginx Load Balancer Startup Script', 
+    description='Docker-based Nginx Load Balancer Startup Script',
     formatter_class=argparse.RawTextHelpFormatter)
 parser.add_argument(
-    '-t', 
-    '--test', 
-    action='store', 
-    choices=['conf', 'parse'], 
+    '-t',
+    '--test',
+    action='store',
+    choices=['conf', 'parse'],
     help=textwrap.dedent('''\
-    Test against your environment variables 
+    Test against your environment variables
     without modifying the config files.
         'conf' - Preview the generated Nginx config file's contents.
         'parse' - View a detailed parsing of the environment.
@@ -208,7 +208,7 @@ def parse_env(env=os.environ):
             ssl_certificate = env.get('%s_SSL_CERTIFICATE' % formatted_hostname)
             ssl_certificate_key = env.get('%s_SSL_CERTIFICATE_KEY' % formatted_hostname)
 
-            assert ssl_certificate, 'SSL certificate .pem not provided for https host: %s, please set %s_SSL_CERTIFICATE' % (hostname, formatted_hostname) 
+            assert ssl_certificate, 'SSL certificate .pem not provided for https host: %s, please set %s_SSL_CERTIFICATE' % (hostname, formatted_hostname)
             assert ssl_certificate_key, 'SSL certificate .key not provided for https host: %s, please set %s_SSL_CERTIFICATE_KEY' % (hostname, formatted_hostname)
             assert os.path.isfile(os.path.join('/etc/nginx/ssl/', ssl_certificate)), 'SSL certificate file: %s could not be found for %s' (ssl_certificate, hostname)
             assert os.path.isfile(os.path.join('/etc/nginx/ssl/', ssl_certificate_key)), 'SSL certificate file: %s could not be found for %s' (ssl_certificate_key, hostname)
@@ -254,15 +254,3 @@ if __name__ == "__main__":
             break
 
     p.stdout.close()
-
-
-
-
-
-
-
-
-
-
-
-

--- a/scripts/templates/proxy.conf
+++ b/scripts/templates/proxy.conf
@@ -13,12 +13,11 @@ upstream {{service_name|lower}} {
 {%- if host['protocols']['http'] %}
 server {
     listen 80;
-    listen [::]:80 ipv6only=on;
     server_name {{hostname}};
 
     root /usr/share/nginx/html;
     {%- for service_name in host['services'] %}
-    
+
     # For service: {{service_name}}
     location {{services[service_name]['location']}} {
         proxy_set_header Host $host;
@@ -33,8 +32,7 @@ server {
 {%- if host['protocols']['https'] %}
 server {
     listen 443;
-
-    server_name localhost;
+    server_name {{hostname}};
 
     root /usr/share/nginx/html;
 
@@ -53,12 +51,11 @@ server {
     location {{services[service_name]['location']}} {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
-        proxy_pass http://{{service_name|lower}};
+        proxy_pass http://{{service_name|lower}}{{services[service_name]['remote_path']}};
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         proxy_buffering off;
-    }
-    {%- endfor %}
+    }{%- endfor %}
 }
 {%- endif %}
 {%- endfor %}

--- a/scripts/templates/proxy.conf
+++ b/scripts/templates/proxy.conf
@@ -24,6 +24,9 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_pass http://{{service_name|lower}}{{services[service_name]['remote_path']}};
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_buffering off;
     }{% endfor %}
 }
 {%- endif %}
@@ -51,6 +54,9 @@ server {
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_pass http://{{service_name|lower}};
+        proxy_http_version 1.1;
+        proxy_set_header Connection "";
+        proxy_buffering off;
     }
     {%- endfor %}
 }


### PR DESCRIPTION
By default, nginx performs reverse proxying using HTTP 1.0, which doesn't support chunked responses and breaks apps which use SSE sockets. This changes so it always uses HTTP 1.1 and never caches or buffers the responses.

Source: [StackOverflow](http://stackoverflow.com/questions/22419434/rails-4-puma-nginx-actioncontrollerlive-streaming-dies-after-first-chunk-s)
