### PR TITLE
Force cipher, protocol and dhparam specification 

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Optional/Conditional environment variables:
     <service-name>_LOG_LEVEL=[emerg|alert|crit|error|warn|notice|info|debug'] (optional - default: error)
     <env-formatted-vhostname>_SSL_CERTIFICATE=<something.pem> (required if the vhost will need ssl support)
     <env-formatted-vhostname>_SSL_CERTIFICATE_KEY=<something.key> (required if the vhost will need ssl support)
+    <env-formatted-vhostname>_SSL_DHPARAM=<dhparam.pem> (required if the vhost will need ssl support)
+    <env-formatted-vhostname>_SSL_CIPHERS=<"colon separated ciphers wrapped in quotes"> (required if the vhost will need ssl support)
+    <env-formatted-vhostname>_SSL_PROTOCOLS=<protocol (e.g. TLSv1.2)> (required if the vhost will need ssl support)
 
 And will build an nginx config file.
 
@@ -44,8 +47,11 @@ Example:
     API_PATH=/api/
     API_EXPOSE_PROTOCOL=https
     API_HOSTNAME=www.example.com
-    WWW_EXAMPLE_COM_SSL_CERTIFICATE=something.pem
-    WWW_EXAMPLE_COM_SSL_CERTIFICATE_KEY=something.key
+    WWW_EXAMPLE_COM_SSL_CERTIFICATE=ssl/something.pem
+    WWW_EXAMPLE_COM_SSL_CERTIFICATE_KEY=ssl/something.key
+    WWW_EXAMPLE_COM_SSL_DHPARAM=ssl/dhparam.pem
+    WWW_EXAMPLE_COM_SSL_CIPHERS="ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256"
+    WWW_EXAMPLE_COM_SSL_PROTOCOLS=TLSv1.2
     TOMCAT_PATH=/javaapp
     TOMCAT_REMOTE_PORT=8080
     TOMCAT_REMOTE_PATH=/javaapp
@@ -99,11 +105,14 @@ Generates (/etc/nginx/sites-enabled/proxy.conf):
         ssl on;
         ssl_certificate ssl/something.pem;
         ssl_certificate_key ssl/something.key;
+        
+        # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
+        ssl_dhparam ssl/dhparam.pem;
 
         ssl_session_timeout 5m;
 
-        ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-        ssl_ciphers "HIGH:!aNULL:!MD5 or HIGH:!aNULL:!MD5:!3DES";
+        ssl_protocols TLSv1.2;
+        ssl_ciphers "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256";
         ssl_prefer_server_ciphers on;
 
         root /usr/share/nginx/html;

--- a/scripts/startup.py
+++ b/scripts/startup.py
@@ -215,6 +215,9 @@ def parse_env(env=os.environ):
         if value['protocols']['https']:
             ssl_certificate = env.get('%s_SSL_CERTIFICATE' % formatted_hostname)
             ssl_certificate_key = env.get('%s_SSL_CERTIFICATE_KEY' % formatted_hostname)
+            ssl_dhparam = env.get('%s_SSL_DHPARAM' % formatted_hostname)
+            ssl_ciphers = env.get('%s_SSL_CIPHERS' % formatted_hostname)
+            ssl_protocols = env.get('%s_SSL_PROTOCOLS' % formatted_hostname)
 
             assert ssl_certificate, 'SSL certificate .pem not provided for https host: %s, please set %s_SSL_CERTIFICATE' % (hostname, formatted_hostname)
             assert ssl_certificate_key, 'SSL certificate .key not provided for https host: %s, please set %s_SSL_CERTIFICATE_KEY' % (hostname, formatted_hostname)

--- a/scripts/startup.py
+++ b/scripts/startup.py
@@ -218,11 +218,18 @@ def parse_env(env=os.environ):
 
             assert ssl_certificate, 'SSL certificate .pem not provided for https host: %s, please set %s_SSL_CERTIFICATE' % (hostname, formatted_hostname)
             assert ssl_certificate_key, 'SSL certificate .key not provided for https host: %s, please set %s_SSL_CERTIFICATE_KEY' % (hostname, formatted_hostname)
+            assert ssl_dhparam, 'SSL dhparam .pem not provided for https host: %s, please set %s_SSL_DHPARAM' % (hostname, formatted_hostname)
             assert os.path.isfile(os.path.join('/etc/nginx/', ssl_certificate)), 'SSL certificate file: %s could not be found for %s' % (ssl_certificate, hostname)
             assert os.path.isfile(os.path.join('/etc/nginx/', ssl_certificate_key)), 'SSL certificate file: %s could not be found for %s' % (ssl_certificate_key, hostname)
+            assert os.path.isfile(os.path.join('/etc/nginx/', ssl_certificate_key)), 'SSL dhparam file: %s could not be found for %s' % (ssl_dhparam, hostname)
+            assert ssl_ciphers, 'SSL ciphers have not been provided for https host: %s, please set %s_SSL_CIPHERS (e.g. %s_SSL_CIPHERS="ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256")' % (hostname, formatted_hostname)
+            assert ssl_protocols, 'SSL protocols have not been provided for https host: %s, please set %s_SSL_PROTOCOLS (e.g. %s_SSL_PROTOCOLS=TLSv1.2)' % (hostname, formatted_hostname)
 
             value['ssl_certificate'] = ssl_certificate
             value['ssl_certificate_key'] = ssl_certificate_key
+            value['ssl_dhparam'] = ssl_dhparam
+            value['ssl_ciphers'] = ssl_ciphers
+            value['ssl_protocols'] = ssl_protocols
 
     return hosts, services
 

--- a/scripts/templates/proxy.conf
+++ b/scripts/templates/proxy.conf
@@ -54,11 +54,14 @@ server {
     ssl on;
     ssl_certificate {{host['ssl_certificate']}};
     ssl_certificate_key {{host['ssl_certificate_key']}};
+    
+    # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
+    ssl_dhparam {{host['ssl_dhparam']}};
 
     ssl_session_timeout 5m;
 
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-    ssl_ciphers "HIGH:!aNULL:!MD5 or HIGH:!aNULL:!MD5:!3DES";
+    ssl_protocols {{host['ssl_protocols']}};
+    ssl_ciphers {{host['ssl_ciphers']}};
     ssl_prefer_server_ciphers on;
 
     {%- for service_name in host['services'] %}


### PR DESCRIPTION
Hi @jasonwyatt thanks a lot for your work on this.

I was using your repo the other day and noticed that the template proxy.conf file was using older cipher suites. 

Chrome informs you if your server has not been configured to use a more modern cipher suite.  While you still get a green padlock, it was one of those warnings that made me want to see what I could do to contribute.

I noticed there wasn't a quick way to make the config more secure on the fly yet so I thought I'd take a look at adding that.

This PR is based on recommendations which allow a user to make the nginx SSL configuration more secure.

The consequence of merging this PR would be the need to define some additional environment variables when enabling SSL.  The advantage is more control over security settings.

I've updated the README.md file accordingly.

Some references:
https://weakdh.org/sysadmin.html - recommendations regarding deploying (Ephemeral) Elliptic-Curve Diffie-Hellman (ECDHE).
https://mozilla.github.io/server-side-tls/ssl-config-generator/?server=nginx-1.4.6&openssl=1.0.1f&hsts=no&profile=intermediate - recommendations for nginx SSL config assuming you want compatibility for older clients.  You can see more modern configuration by selecting the relevant option with the tool.

BTW the Mozilla tool mentioned above is pretty useful for creating more secure configs for nginx and apache.

All the best,
Dave
